### PR TITLE
支持 PhpStorm 2019.1 的 meta 文件

### DIFF
--- a/src/.phpstorm.meta.php
+++ b/src/.phpstorm.meta.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PHPSTORM_META {
+
+    /**
+     * swoole 支持的 Socket 类型
+     * @link https://wiki.swoole.com/wiki/page/16.html
+     */
+    registerArgumentsSet('swoole_sock_type',
+        SWOOLE_SOCK_TCP, SWOOLE_SOCK_TCP6,
+        SWOOLE_SOCK_UDP, SWOOLE_SOCK_UDP6,
+        SWOOLE_SOCK_UNIX_DGRAM, SWOOLE_UNIX_DGRAM,
+        SWOOLE_SOCK_UNIX_STREAM, SWOOLE_UNIX_STREAM
+    );
+
+    expectedArguments(\Swoole\Server::__construct(), 2, SWOOLE_BASE, SWOOLE_PROCESS);
+
+    expectedArguments(\Swoole\Server::__construct(), 3, argumentsSet('swoole_sock_type'));
+    expectedArguments(\Swoole\Server::listen(), 2, argumentsSet('swoole_sock_type'));
+    expectedArguments(\Swoole\Server::addListener(), 2, argumentsSet('swoole_sock_type'));
+
+    expectedArguments(\Swoole\Client::__construct(), 0, argumentsSet('swoole_sock_type'));
+    expectedArguments(\Swoole\Client::__construct(), 1, SWOOLE_SOCK_SYNC, SWOOLE_SOCK_ASYNC);
+
+    expectedArguments(\Swoole\Lock::__construct(), 0,
+        SWOOLE_FILELOCK,
+        SWOOLE_MUTEX,
+        SWOOLE_SEM,
+        SWOOLE_RWLOCK,
+        SWOOLE_SPINLOCK
+    );
+
+    expectedArguments(\Swoole\Process\Pool::__construct(), 1, SWOOLE_IPC_MSGQUEUE, SWOOLE_IPC_SOCKET);
+}

--- a/src/.phpstorm.meta.php
+++ b/src/.phpstorm.meta.php
@@ -9,8 +9,8 @@ namespace PHPSTORM_META {
     registerArgumentsSet('swoole_sock_type',
         SWOOLE_SOCK_TCP, SWOOLE_SOCK_TCP6,
         SWOOLE_SOCK_UDP, SWOOLE_SOCK_UDP6,
-        SWOOLE_SOCK_UNIX_DGRAM, SWOOLE_UNIX_DGRAM,
-        SWOOLE_SOCK_UNIX_STREAM, SWOOLE_UNIX_STREAM
+        SWOOLE_SOCK_UNIX_DGRAM,
+        SWOOLE_SOCK_UNIX_STREAM
     );
 
     expectedArguments(\Swoole\Server::__construct(), 2, SWOOLE_BASE, SWOOLE_PROCESS);

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -6,6 +6,7 @@ define('SWOOLE_PROCESS', 3);
 define('SWOOLE_IPC_UNSOCK', 1);
 define('SWOOLE_IPC_MSGQUEUE', 2);
 define('SWOOLE_IPC_PREEMPTIVE', 3);
+define('SWOOLE_IPC_SOCKET', 3);
 define('SWOOLE_SOCK_TCP', 1);
 define('SWOOLE_SOCK_TCP6', 3);
 define('SWOOLE_SOCK_UDP', 2);

--- a/src/Process/Pool.php
+++ b/src/Process/Pool.php
@@ -16,6 +16,8 @@ class Pool
 {
     /**
      * Pool constructor.
+     * 进程池介绍 https://wiki.swoole.com/wiki/page/901.html
+     *
      * @param int $worker_num
      * @param int $ipc_type
      * @param int $msgqueue_key


### PR DESCRIPTION
处于 EAP 阶段的 PhpStorm 2019.1 提供了 [expectedArguments](https://blog.jetbrains.com/phpstorm/2019/02/new-phpstorm-meta-php-features/) 特性，实现 参数可选项声明 功能。

此 PL 提交的 _.phpstorm.meta.php_ 实现了 _\Swoole\Server_ 和 _\Swoole\Client_ 的几个参数的可选项声明，已经在 PhpStorm 2019.1 中进行过测试。

### 为什么有 SWOOLE_SOCK_TCP 而没有 SWOOLE_TCP
SWOOLE_TCP 是 Swoole 早期版本定义的常量。在 2016年11月发布的 [Swoole 2.0.1](https://github.com/swoole/swoole-src/blob/v2.0.1/swoole.c#L573) 已经实现了 SWOOLE_SOCK_TCP 等常量，加入重复的 SWOOLE_TCP 会加重开发者了解这些信息的负担。