### PR TITLE
Some stubs are using scalar type declarations which is introduced in …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
             "role": "lead"
         }
     ],
+    "require": {
+        "php": ">=7.0"
+    },
     "autoload-dev": {
         "psr-4": {
             "Swoole\\": "src"


### PR DESCRIPTION
Very minor issue. Some stubs are using scalar type declarations. Scalar type declarations are  introduced in PHP 7.0.

